### PR TITLE
removes extra bullet on discord point

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Share your apps here! send a pull request!
 ## Communities 
 
 * [Appwrite Blog](https://medium.com/appwrite-io) (Official, global)
-* * [Discord Server](https://discord.gg/GSeTUeA) (Official, global)
+* [Discord Server](https://discord.gg/GSeTUeA) (Official, global)
 * [Twitter](https://twitter.com/appwrite_io) (Official, global)
 * [Facebook](https://www.facebook.com/appwrite.io/) (Official, global)
 * [Appwrite Developers on Facebook](https://www.facebook.com/groups/appwrite.developers/?source_id=227046654430085) (Official, global)


### PR DESCRIPTION
the extra bullet was making it a subheading of appwrite blog point hence was removed to maintain consistency.