### PR TITLE
Add Appwrite Explorer Tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Share your apps here! send a pull request!
 * [Appwrite extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=Streamlux.vscode-appwrite) proudly built by [@alexweininger](https://github.com/alexweininger) and the [@streamlux](https://github.com/streamlux) team.
 * [Appwrite CLI](https://github.com/appwrite/sdk-for-cli) interact with your Appwrite server side APIs from your terminal.
 * [Flutter Appwrite Account Kit](https://github.com/lohanidamodar/flappwrite_account_kit)
+* [Appwrite Explorer](https://github.com/stnguyen90/appwrite-explorer) explore different aspects of an Appwrite project from the front end
 
 ## Communities 
 


### PR DESCRIPTION
Appwrite Explorer is a tool/demo app to explore aspects of an Appwrite instance from the front end. Can this be added to the tools section?

Also, I know the Hacktoberfest issue mentioned including the made with appwrite badge, but I wasn't sure if it was needed and where it should go.

Relates: https://github.com/appwrite/appwrite/issues/1773