### PR TITLE
Add Almost Netflix to TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 ## Table of Contents:
   - [Announcements and Official Blog Posts](#announcements-and-official-blog-posts)
-  - [30 Days of Appwrite](#30-days-of-appwrite-)
+    - [30 Days of Appwrite](#30-days-of-appwrite-)
+    - [Almost Netflix](#almost-netflix-)
   - [Hacktoberfest 2021](#hacktoberfest-2021) 
   - [Learning Resources](#learning-resources)
     - [Getting Started](#getting-started)


### PR DESCRIPTION
In my previous PR, I forgot to add Almost Netflix to the Table of Contents. This updates the TOC to include Almost Netlfix but also updates the indentation of 30 Days of Appwrite since it's a level 3 heading rather than 2.

Is it even worth it to add this manually maintained TOC anymore considering Github has it [built in](https://github.blog/changelog/2021-04-13-table-of-contents-support-in-markdown-files/)?