### PR TITLE
Add: Learning resource (blog) on Mobile Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ The Almost Netflix series is a tutorial for building a Netflix clone with Appwri
 * [Introduction to Appwrite Cloud Functions with Android and Kotlin](https://hardiksachan.hashnode.dev/introduction-to-appwrite-cloud-functions-with-android-and-kotlin)
 * [Dart in Appwrite](https://dev.to/oshi36/dart-in-appwrite-47e)
 * [Appwrite + Appcelerator Titanium: A step by step guide](https://github.com/m1ga/from_zero_to_app/blob/master/appwrite_app.md)
+* [Write Unit Tests for Appwrite SDK on Flutter With Mockito](https://betterprogramming.pub/write-unit-test-for-appwrite-sdk-on-flutter-with-mockito-e0c3b403199e)
 
 ### Security and Authentication
 * [Restricting Access to Your Appwrite Console](https://medium.com/appwrite-io/you-can-now-restrict-access-to-your-appwrite-console-b8b447885289?source=friends_link&sk=95b78cf75ff633e0f32b8a76ea619b08)


### PR DESCRIPTION
Hi, I just publish an article about **How to Write Unit Test for Appwrite SDK on Flutter** on Medium. I want to add this article to the learning resource for mobile development. Hopefully, this will help other developers who want to apply Test-Driven Development to their projects while using Appwrite SDK.

Blog Link: https://betterprogramming.pub/write-unit-test-for-appwrite-sdk-on-flutter-with-mockito-e0c3b403199e

Thank you!