### PR TITLE
Added a How to install appwrite on hetzner tutorial.

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ The Almost Netflix series is a tutorial for building a Netflix clone with Appwri
 * [Integrate Adalo with Appwrite](https://imknight.com/integrate-adalo-with-appwrite/)
 * [How to install and configure Appwrite on CyberPanel](https://tafadzwa.hashnode.dev/how-to-install-and-configure-appwrite-on-cyberpanel)
 * [How to install Appwrite on Amazon EC2 instance](https://awstip.com/installing-appwrite-on-amazon-ec2-instance-13f6744f2b48)
+* [How to install Appwrite on a Hetzner cloud server](https://dev.to/gregordavies/how-to-install-appwrite-on-a-hetzner-cloud-server-in-8-steps-1lan)
 
 ### Web Development
 * [Node.JS in Appwrite](https://dev.to/finnkr/nodejs-in-appwrite-21kk)


### PR DESCRIPTION

## What does this PR do?
This PR includes a tutorial on how to setup Appwrite on a hetzner cloud server. With the tutorial hosted on dev.to and meeting the requirements of the issue #4009 in the appwrite repo.

## Test Plan

To test it you can follow the steps on how to install appwrite on a hetzner cloud server.

## Related PRs and Issues

#4009 in the appwrite repo (https://github.com/appwrite/appwrite/issues/4009)

### Have you read the [Contributing Guidelines on issues]
Yes