### PR TITLE
Add Discordly and App-ly to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,8 @@ Share your apps here! Submit a pull request!
 ### Android
 * **Appwrite + Kotlin Android App -> Taleia** - A simple app that generates sets of random word combinations to fight the writer's block. It Allows to log in and save them with Appwrite to be able to retreive the liked combinations later. [Source Code](https://github.com/und1n3/taleia)
 
-
+### Discord Bot
+* **Discordly** A Discord-bot to readily and easily shorten links from Discord itself, made possible by Appwrite. [Source Code](https://github.com/Arpan-206/discordly)
 
 ## Videos
 

--- a/README.md
+++ b/README.md
@@ -306,6 +306,8 @@ Share your apps here! Submit a pull request!
 
 * **TMStats** A medal tracker for game Trackmania made with Appwrite and Svelte Kit. [Source Code](https://github.com/meldiron/tmstats) [Demo](https://www.tmstats.eu/)
 
+* **App-ly** App-ly is an open-source URL shortener made using Svelte and Appwrite. It is a web app that allows you to shorten long URLs, share them, and generate QR Codes for them. [Source Code](https://github.com/Arpan-206/app-ly)
+
 ### Vue
 * **Appwrite + Vue.js CRUD** This is a Vue.js App made to interact with a Appwrite Server [Source Code](https://github.com/Anstroy/countries-app-vue)
 


### PR DESCRIPTION
## What does this PR do?

It adds to 2 projects to the README.

- **App-ly**: App-ly is an open-source URL shortener made using Svelte and Appwrite. It is a web app that allows you to shorten long URLs, share them, and generate QR Codes for them.

- **Discordly**: A Discord-bot to readily and easily shorten links from [Discord](https://discord.com/) itself, made possible by [Appwrite](https://appwrite.io/).


## Test Plan

N/A

## Related PRs and Issues

[Dream Contrib](https://github.com/appwrite/appwrite/issues/4024#issuecomment-1281083774)
[Almost Bitly](https://github.com/appwrite/appwrite/issues/4307)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes, I have.