### PR TITLE
doc: Added "Deploy Appwrite to Google Cloud" resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ The Almost Netflix series is a tutorial for building a Netflix clone with Appwri
 * [Integrate Adalo with Appwrite](https://imknight.com/integrate-adalo-with-appwrite/)
 * [How to install and configure Appwrite on CyberPanel](https://tafadzwa.hashnode.dev/how-to-install-and-configure-appwrite-on-cyberpanel)
 * [How to install Appwrite on Amazon EC2 instance](https://awstip.com/installing-appwrite-on-amazon-ec2-instance-13f6744f2b48)
+* [Deploy Appwrite on Google Cloud](https://blog.wilfredalmeida.com/appwrite-on-google-cloud)
 
 ### Web Development
 * [Node.JS in Appwrite](https://dev.to/finnkr/nodejs-in-appwrite-21kk)


### PR DESCRIPTION
Added "Deploy Appwrite to Google Cloud" blog resource


## What does this PR do?

Added a blog resource in README.md on how to deploy Appwrite on Google Cloud Compute Engine VM

## Test Plan

NA

## Related PRs and Issues

NA

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes