### PR TITLE
Added fetch-appwrite-types package

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,7 @@ Share your apps here! Submit a pull request!
 * [Appwrite Starter](https://www.npmjs.com/package/create-appwrite) start building faster with this initializer for web frameworks
 * [Appwrite React Admin Data Provider](https://www.npmjs.com/package/ra-appwrite) Data and Auth Providers to integrate [React Admin](https://marmelab.com/react-admin/) with Appwrite
 * [Awesome Appwrite snippets](https://marketplace.visualstudio.com/items?itemName=Biswa.awesome-appwrite-snippets) that adds Live Templates to your IDE saving time writing the boilerplate in Appwrite.
+* [Fetch Appwrite Types](https://github.com/YsarocK/fetch-appwrite-types) generate Typescript Interfaces from Appwrite DB
 
 ## Communities
 


### PR DESCRIPTION
## What does this PR do?

This PR adds a line about the fetch-appwrite-types package, which generates Typescript types from an Appwrite instance. Might be usefull for all TS users.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes