### PR TITLE
Add link to Helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,7 @@ Share your apps here! Submit a pull request!
 * [Appwrite Starter](https://www.npmjs.com/package/create-appwrite) start building faster with this initializer for web frameworks
 * [Appwrite React Admin Data Provider](https://www.npmjs.com/package/ra-appwrite) Data and Auth Providers to integrate [React Admin](https://marmelab.com/react-admin/) with Appwrite
 * [Awesome Appwrite snippets](https://marketplace.visualstudio.com/items?itemName=Biswa.awesome-appwrite-snippets) that adds Live Templates to your IDE saving time writing the boilerplate in Appwrite.
+* [Appwrite Helm chart](https://github.com/fpoussin/appwrite-helm) to deploy all components on Kubernetes.
 
 ## Communities
 


### PR DESCRIPTION
## What does this PR do?
Adding a link to the repository hosting a Helm chart for Appwrite.

## Related PRs and Issues

https://github.com/appwrite/appwrite/pull/5276

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.