### PR TITLE
Add appwrite-security-skill (MIT auditor)

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,6 @@ The Almost Netflix series is a tutorial for building a Netflix clone with Appwri
 
 - [Restricting Access to Your Appwrite Console](https://medium.com/appwrite-io/you-can-now-restrict-access-to-your-appwrite-console-b8b447885289?source=friends_link&sk=95b78cf75ff633e0f32b8a76ea619b08)
 - [Full List of Appwrite Environment Variables](https://appwrite.io/docs/environment-variables)
-- [appwrite-security-skill](https://github.com/Perufitlife/appwrite-security-skill) - Open-source MIT auditor that probes anonymously to find "any" role grants on collections, public storage buckets, and unprotected execute-functions in your Appwrite project. Outputs an HTML report with copy-paste fix snippets. Hosted run on Apify (no install): [apify.com/renzomacar/appwrite-security-auditor](https://apify.com/renzomacar/appwrite-security-auditor).
 
 ### Appwrite Services
 
@@ -541,6 +540,7 @@ Share your apps here! Submit a pull request!
 - [Fetch Appwrite Types](https://github.com/YsarocK/fetch-appwrite-types) generate Typescript Interfaces from Appwrite DB
 - [AdminWrite](https://github.com/singhbhaskar/AdminWrite) helper tool for Appwrite to perform bulk operations during development for Database and Users.
 - [Appwrite Funcover](https://github.com/BoolCode/appwrite-funcover) "Cover" your Appwrite G3 functions with a dedicated endpoint, for static pages, direct execution and more.
+- [appwrite-security-skill](https://github.com/Perufitlife/appwrite-security-skill) MIT-licensed security auditor — finds "any" role grants, public buckets, and unprotected functions.
 
 ## Communities
 

--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ The Almost Netflix series is a tutorial for building a Netflix clone with Appwri
 
 - [Restricting Access to Your Appwrite Console](https://medium.com/appwrite-io/you-can-now-restrict-access-to-your-appwrite-console-b8b447885289?source=friends_link&sk=95b78cf75ff633e0f32b8a76ea619b08)
 - [Full List of Appwrite Environment Variables](https://appwrite.io/docs/environment-variables)
+- [appwrite-security-skill](https://github.com/Perufitlife/appwrite-security-skill) - Open-source MIT auditor that probes anonymously to find "any" role grants on collections, public storage buckets, and unprotected execute-functions in your Appwrite project. Outputs an HTML report with copy-paste fix snippets. Hosted run on Apify (no install): [apify.com/renzomacar/appwrite-security-auditor](https://apify.com/renzomacar/appwrite-security-auditor).
 
 ### Appwrite Services
 


### PR DESCRIPTION
Adding **appwrite-security-skill** to the **Security and Authentication** section.

It's an MIT-licensed auditor that probes anonymously to confirm three classes of leak in Appwrite projects:
- "any" role grants left on collections after prototyping
- Public Storage buckets with broad read permissions
- Unprotected execute-functions exposed to anonymous

Outputs an HTML report with copy-paste fix snippets. Hosted run on Apify (no install): [apify.com/renzomacar/appwrite-security-auditor](https://apify.com/renzomacar/appwrite-security-auditor).

Source code: [github.com/Perufitlife/appwrite-security-skill](https://github.com/Perufitlife/appwrite-security-skill).